### PR TITLE
Remove changelog link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,6 @@ kotakanbe ([@kotakanbe](https://twitter.com/kotakanbe)) created go-cpe-dictionar
 
 ----
 
-# Change Log
-
-Please see [CHANGELOG](https://github.com/kotakanbe/go-cpe-dictionary/blob/master/CHANGELOG.md).
-
-----
-
 # Licence
 
 Please see [LICENSE](https://github.com/kotakanbe/go-cpe-dictionary/blob/master/LICENSE).


### PR DESCRIPTION
There is no CHANGELOG in this repository.

This PR removed CHANGELOG link and section from README.