### PR TITLE
fix(redis): insert CPE with `version: Any`

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -75,10 +75,6 @@ func (r *RedisDriver) InsertCpes(cpes []*models.CategorizedCpe) (err error) {
 		pipe = r.conn.Pipeline()
 		for _, c := range chunked {
 			bar.Increment()
-			if c.Version == "ANY" {
-				continue
-			}
-
 			if result := pipe.ZAdd(
 				ctx,
 				hashKeyPrefix+"CpeURI",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2020-5626

# before

```
ubuntu@dev:~$ redis-cli -n 9 zrange CPE#VendorProduct 0 -1 | grep infoscience
ubuntu@dev  ~  redis-cli -n 9 zrange CPE#CpeURI 0 -1 | grep infoscience
ubuntu@dev  ~  redis-cli -n 9 zrange CPE#infoscience::logstorage 0 -1
(empty list or set)
```

# after 

```
redis-cli -n 9 zrange CPE#infoscience::logstorage 0 -1
1) "cpe:/a:infoscience:logstorage"
redis-cli -n 9 zrange CPE#CpeURI 0 -1 | grep infoscience
cpe:/a:infoscience:elc_analytics
cpe:/a:infoscience:logstorage
redis-cli -n 9 zrange CPE#VendorProduct 0 -1 | grep infoscience
infoscience::elc_analytics
infoscience::logstorage
```

# test

```
sqlite> select count(*) from categorized_cpes limit 1;
781826
 ubuntu@dev  ~│g│s│g│k│go-cpe-dictionary  ⎇ insert-all-cpe~  redis-cli -n 9 zrange CPE#CpeURI 0 -1 | wc -l
781826
```