### PR TITLE
feat(server): add server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ sqlite3 ./cpe.sqlite3 'select cpe_uri from categorized_cpes' | peco
 
 # Usage:
 
-```
+```console
 $ go-cpe-dictionary -help
 Usage: go-cpe-dictionary <flags> <subcommand> <subcommand args>
 
@@ -88,13 +88,19 @@ Subcommands:
 	flags            describe all known top-level flags
 	help             describe subcommands and their syntax
 
+Subcommands for fetchjvn:
+	fetchjvn         Fetch CPE from JVN
+
 Subcommands for fetchnvd:
 	fetchnvd         Fetch CPE from NVD
+
+Subcommands for server:
+	server           Start CPE dictionary HTTP server
 
 
 Use "go-cpe-dictionary flags" for a list of top-level flags
 
-$ go-cpe-dictionary fetchnvd -help
+$ go-cpe-dictionary fetchnvd --help
 fetchnvd:
 	fetchnvd
 		[-dbtype=mysql|postgres|sqlite3|redis]
@@ -102,11 +108,14 @@ fetchnvd:
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
+		[-log-to-file]
 		[-log-dir=/path/to/log]
 		[-log-json]
+		[-stdout]
 
 For the first time, run the blow command to fetch data. (It takes about 10 minutes)
-   $ go-cpe-dictionary fetchnvd
+   $ ./go-cpe-dictionary fetchnvd
+   $ ./go-cpe-dictionary fetchnvd --stdout | sort -u > /tmp/nvd.txt
   -dbpath string
     	/path/to/sqlite3 or SQL connection string (default "$PWD/cpe.sqlite3")
   -dbtype string
@@ -118,10 +127,84 @@ For the first time, run the blow command to fetch data. (It takes about 10 minut
   -http-proxy string
     	http://proxy-url:port (default: empty)
   -log-dir string
-    	/path/to/log (default "/var/log/vuls")
+    	/path/to/log (default "/var/log/go-cpe-dictionary")
   -log-json
     	output log as JSON
+  -log-to-file
+    	output log to file
+  -stdout
+    	display all CPEs to stdout
 
+$ go-cpe-dictionary fetchjvn --help
+fetchjvn:
+	fetchjvn
+		[-dbtype=mysql|postgres|sqlite3|redis]
+		[-dbpath=$PWD/cpe.sqlite3 or connection string]
+		[-http-proxy=http://192.168.0.1:8080]
+		[-debug]
+		[-log-to-file]
+		[-log-dir=/path/to/log]
+		[-log-json]
+
+   $ go-cpe-dictionary fetchjvn | sort -u > /tmp/jvn.txt
+  -dbpath string
+    	/path/to/sqlite3 or SQL connection string (default "$PWD/cpe.sqlite3")
+  -dbtype string
+    	Database type to store data in (sqlite3, mysql, postgres or redis supported) (default "sqlite3")
+  -debug
+    	debug mode
+  -debug-sql
+    	SQL debug mode
+  -http-proxy string
+    	http://proxy-url:port (default: empty)
+  -log-dir string
+    	/path/to/log (default "/var/log/go-cpe-dictionary")
+  -log-json
+    	output log as JSON
+  -log-to-file
+    	output log to file
+  -stdout
+    	display all CPEs to stdout
+
+$ go-cpe-dictionary server --help
+server:
+	server
+		[-bind=127.0.0.1]
+		[-port=8000]
+		[-dbtype=mysql|postgres|sqlite3|redis]
+		[-dbpath=$PWD/cpe.sqlite3 or connection string]
+		[-http-proxy=http://192.168.0.1:8080]
+		[-debug]
+		[-debug-sql]
+		[-log-to-file]
+		[-log-dir=/path/to/log]
+		[-log-json]
+		[-stdout]
+
+For the first time, run the blow command to fetch data. (It takes about 10 minutes)
+   $ ./go-cpe-dictionary server
+  -bind string
+    	HTTP server bind to IP address (default: loop back interface) (default "127.0.0.1")
+  -dbpath string
+    	/path/to/sqlite3 or SQL connection string (default "$PWD/cpe.sqlite3")
+  -dbtype string
+    	Database type to store data in (sqlite3, mysql, postgres or redis supported) (default "sqlite3")
+  -debug
+    	debug mode
+  -debug-sql
+    	SQL debug mode
+  -http-proxy string
+    	http://proxy-url:port (default: empty)
+  -log-dir string
+    	/path/to/log (default "/var/log/go-cpe-dictionary")
+  -log-json
+    	output log as JSON
+  -log-to-file
+    	output log to file
+  -port string
+    	HTTP server port number (default "1323")
+  -stdout
+    	display all CPEs to stdout
 ```
 
 ----
@@ -138,7 +221,7 @@ If your system is behind HTTP proxy, you have to specify --http-proxy option.
     ```
 
 - Debug  
-Run with --debug, --sql-debug option.
+Run with --debug, --debug-sql option.
 
 ----
 

--- a/commands/server.go
+++ b/commands/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/subcommands"
 	"github.com/inconshreveable/log15"
 	"github.com/kotakanbe/go-cpe-dictionary/config"
+	"github.com/kotakanbe/go-cpe-dictionary/db"
 	"github.com/kotakanbe/go-cpe-dictionary/server"
 	"github.com/kotakanbe/go-cpe-dictionary/util"
 )
@@ -81,8 +82,14 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		return subcommands.ExitUsageError
 	}
 
+	driver, err := db.NewDB(config.Conf.DBType, config.Conf.DBPath, config.Conf.DebugSQL)
+	if err != nil {
+		log15.Error("Failed to new DB.", "err", err)
+		return subcommands.ExitFailure
+	}
+
 	log15.Info("Starting HTTP Server...")
-	if err := server.Start(p.logDir); err != nil {
+	if err := server.Start(p.logDir, driver); err != nil {
 		log15.Error("Failed to start server", "err", err)
 		return subcommands.ExitFailure
 	}

--- a/commands/server.go
+++ b/commands/server.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"context"
+	"flag"
+	"os"
+
+	"github.com/google/subcommands"
+	"github.com/inconshreveable/log15"
+	"github.com/kotakanbe/go-cpe-dictionary/config"
+	"github.com/kotakanbe/go-cpe-dictionary/server"
+	"github.com/kotakanbe/go-cpe-dictionary/util"
+)
+
+// ServerCmd : ServerCmd
+type ServerCmd struct {
+	logToFile bool
+	logDir    string
+	logJSON   bool
+}
+
+// Name return subcommand name
+func (*ServerCmd) Name() string { return "server" }
+
+// Synopsis return synopsis
+func (*ServerCmd) Synopsis() string { return "Start CPE dictionary HTTP server" }
+
+// Usage return usage
+func (*ServerCmd) Usage() string {
+	return `server:
+	server
+		[-bind=127.0.0.1]
+		[-port=8000]
+		[-dbtype=mysql|postgres|sqlite3|redis]
+		[-dbpath=$PWD/cpe.sqlite3 or connection string]
+		[-http-proxy=http://192.168.0.1:8080]
+		[-debug]
+		[-debug-sql]
+		[-log-to-file]
+		[-log-dir=/path/to/log]
+		[-log-json]
+		[-stdout]
+
+For the first time, run the blow command to fetch data. (It takes about 10 minutes)
+   $ ./go-cpe-dictionary server
+`
+}
+
+// SetFlags set flag
+func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&config.Conf.Debug, "debug", false, "debug mode")
+	f.BoolVar(&config.Conf.DebugSQL, "debug-sql", false, "SQL debug mode")
+
+	defaultLogDir := util.GetDefaultLogDir()
+	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
+	f.BoolVar(&p.logJSON, "log-json", false, "output log as JSON")
+	f.BoolVar(&p.logToFile, "log-to-file", false, "output log to file")
+	f.BoolVar(&config.Conf.Stdout, "stdout", false, "display all CPEs to stdout")
+
+	pwd := os.Getenv("PWD")
+	f.StringVar(&config.Conf.DBPath, "dbpath", pwd+"/cpe.sqlite3",
+		"/path/to/sqlite3 or SQL connection string")
+
+	f.StringVar(&config.Conf.DBType, "dbtype", "sqlite3",
+		"Database type to store data in (sqlite3, mysql, postgres or redis supported)")
+
+	f.StringVar(&config.Conf.HTTPProxy, "http-proxy", "", "http://proxy-url:port (default: empty)")
+
+	f.StringVar(&config.Conf.Bind,
+		"bind",
+		"127.0.0.1",
+		"HTTP server bind to IP address (default: loop back interface)")
+	f.StringVar(&config.Conf.Port, "port", "1323",
+		"HTTP server port number")
+}
+
+// Execute execute
+func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	util.SetLogger(p.logDir, config.Conf.Debug, p.logJSON, p.logToFile)
+	if !config.Conf.Validate() {
+		return subcommands.ExitUsageError
+	}
+
+	log15.Info("Starting HTTP Server...")
+	if err := server.Start(p.logDir); err != nil {
+		log15.Error("Failed to start server", "err", err)
+		return subcommands.ExitFailure
+	}
+	return subcommands.ExitSuccess
+}

--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,8 @@ type Config struct {
 	DBPath string
 	DBType string
 
-	Bind string
-	Port string
+	Bind string `valid:"ipv4"`
+	Port string `valid:"port"`
 
 	Stdout bool
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cheggaaa/pb/v3 v3.0.8
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/elazarl/goproxy v0.0.0-20200426045556-49ad98f6dac1 // indirect
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/go-redis/redis/v8 v8.10.0
@@ -19,6 +20,8 @@ require (
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/knqyf263/go-cpe v0.0.0-20201213041631-54f6ab28673f
+	github.com/labstack/echo v3.3.10+incompatible
+	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/lib/pq v1.10.2 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
@@ -26,8 +29,10 @@ require (
 	github.com/parnurzeal/gorequest v0.2.16
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/valyala/fasttemplate v1.2.1 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20200603152657-dc2b0ca8b37e // indirect
 	go.opentelemetry.io/otel/internal/metric v0.21.0 // indirect
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
 	moul.io/http2curl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6ROGeiHFAP8WJdI2RoxALQYgdllERc3N5N2DM=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/elazarl/goproxy v0.0.0-20200426045556-49ad98f6dac1 h1:TEmChtx8+IeOghiySC8kQIr0JZOdKUmRmmkuRDuYs3E=
@@ -78,11 +80,18 @@ github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd
 github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/knqyf263/go-cpe v0.0.0-20201213041631-54f6ab28673f h1:vZP1dTKPOR7zSAbgqNbnTnYX77+gj3eu0QK+UmANZqE=
 github.com/knqyf263/go-cpe v0.0.0-20201213041631-54f6ab28673f/go.mod h1:4cVhzV/TndScEg4xMtSo3TTz3cMFhEAvhAA4igAyXZY=
+github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
+github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
+github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
+github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1yA=
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
@@ -118,8 +127,14 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52WA1u4=
+github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
 github.com/yuin/gopher-lua v0.0.0-20200603152657-dc2b0ca8b37e h1:oIpIX9VKxSCFrfjsKpluGbNPBGq9iNnT9crH781j9wY=
@@ -141,8 +156,9 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e h1:gsTQYXdTw2Gq7RBsWvlQ91b+aEQ6bXFUngBGuR8sPpI=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -154,6 +170,7 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -162,7 +179,9 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -174,6 +193,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -199,6 +219,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 	subcommands.Register(subcommands.CommandsCommand(), "")
 	subcommands.Register(&commands.FetchNvdCmd{}, "fetchnvd")
 	subcommands.Register(&commands.FetchJvnCmd{}, "fetchjvn")
+	subcommands.Register(&commands.ServerCmd{}, "server")
 
 	var v = flag.Bool("v", false, "Show version")
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/inconshreveable/log15"
+	"github.com/kotakanbe/go-cpe-dictionary/config"
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/middleware"
+)
+
+// Start starts CVE dictionary HTTP Server.
+func Start(logDir string) error {
+	e := echo.New()
+	e.Debug = config.Conf.Debug
+
+	// Middleware
+	e.Use(middleware.Logger())
+	e.Use(middleware.Recover())
+
+	// setup access logger
+	logPath := filepath.Join(logDir, "access.log")
+	if _, err := os.Stat(logPath); os.IsNotExist(err) {
+		if _, err := os.Create(logPath); err != nil {
+			log15.Error("Failed to create log dir", logPath, err)
+		}
+	}
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		log15.Error("Failed to open log file", logPath, err)
+	}
+	defer f.Close()
+	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Output: f,
+	}))
+
+	// Routes
+	e.GET("/health", health())
+
+	bindURL := fmt.Sprintf("%s:%s", config.Conf.Bind, config.Conf.Port)
+	log15.Info("Listening...", "URL", bindURL)
+	return e.Start(bindURL)
+}
+
+// Handler
+func health() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		return c.String(http.StatusOK, "")
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -34,9 +34,9 @@ func GenWorkers(num int) chan<- func() {
 
 // GetDefaultLogDir returns default log directory
 func GetDefaultLogDir() string {
-	defaultLogDir := "/var/log/vuls"
+	defaultLogDir := "/var/log/go-cpe-dictionary"
 	if runtime.GOOS == "windows" {
-		defaultLogDir = filepath.Join(os.Getenv("APPDATA"), "vuls")
+		defaultLogDir = filepath.Join(os.Getenv("APPDATA"), "go-cpe-dictionary")
 	}
 	return defaultLogDir
 }


### PR DESCRIPTION
Added server mode so that the search function can be easily checked.

```console
$ go-cpe-dictionary server
INFO[07-01|17:54:55] Starting HTTP Server... 
INFO[07-01|17:54:55] Listening...                             URL=127.0.0.1:1323

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v3.3.10-dev
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on 127.0.0.1:1323

$ curl http://127.0.0.1:1323/health
$ curl http://127.0.0.1:1323/products | jq
[
    ...
    "squaredup::squaredup",
    "rubrik::copy_data_management",
    "apache::chainsaw"
]

$ curl http://127.0.0.1:1323/cpes/apache/chainsaw | jq
{
  "cpeURIs": [
    "cpe:/a:apache:chainsaw"
  ],
  "deprecated": []
}
```