### PR TITLE
feat(redis): add expire option

### DIFF
--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -19,9 +19,6 @@ var fetchJvnCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(fetchJvnCmd)
-
-	fetchJvnCmd.PersistentFlags().Bool("stdout", false, "display all CPEs to stdout")
-	_ = viper.BindPFlag("stdout", fetchJvnCmd.PersistentFlags().Lookup("stdout"))
 }
 
 func fetchJvn(cmd *cobra.Command, args []string) (err error) {

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -19,9 +19,6 @@ var fetchNvdCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(fetchNvdCmd)
-
-	fetchNvdCmd.PersistentFlags().Bool("stdout", false, "display all CPEs to stdout")
-	_ = viper.BindPFlag("stdout", fetchNvdCmd.PersistentFlags().Lookup("stdout"))
 }
 
 func fetchNvd(cmd *cobra.Command, args []string) (err error) {

--- a/commands/root.go
+++ b/commands/root.go
@@ -49,6 +49,12 @@ func init() {
 
 	RootCmd.PersistentFlags().String("http-proxy", "", "http://proxy-url:port (default: empty)")
 	_ = viper.BindPFlag("http-proxy", RootCmd.PersistentFlags().Lookup("http-proxy"))
+
+	RootCmd.PersistentFlags().Bool("stdout", false, "display all CPEs to stdout")
+	_ = viper.BindPFlag("stdout", RootCmd.PersistentFlags().Lookup("stdout"))
+
+	RootCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys")
+	_ = viper.BindPFlag("expire", RootCmd.PersistentFlags().Lookup("expire"))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Unlike RDBs, Redis does not lose old data. For users who do not want to be affected by old data remaining, it is possible to set a timeout deadline for keys using the Redis EXPIRE command.

# How Has This Been Tested?
```console
$ redis-cli -p 6379
127.0.0.1:6379> TTL "CPE#VendorProduct"
(integer) 95
127.0.0.1:6379> TTL "CPE#amazon::echo_dot"
(integer) 63
127.0.0.1:6379> TTL "CPE#dep#cpe:/a:jenkins:jenkins:1.545"
(integer) 50
127.0.0.1:6379> keys CPE#*
(empty array)
```

# Reference
- https://redis.io/commands/expire